### PR TITLE
add flag UTF8Atom in enum NodeCompatibility

### DIFF
--- a/Source/NFX.Erlang/Connect/ErlAbstractNode.cs
+++ b/Source/NFX.Erlang/Connect/ErlAbstractNode.cs
@@ -80,8 +80,9 @@ namespace NFX.Erlang
       ExtendedPidsPorts   = 256, // pshaffer
       BitBinaries         = 1024,
       NewFloats           = 2048,
+      UTF8Atom            = 65536,
       Flags               = ExtendedReferences | ExtendedPidsPorts
-                          | BitBinaries | NewFloats | DistMonitor,  // pshaffer
+                          | BitBinaries | NewFloats | DistMonitor | UTF8Atom,  // pshaffer
     }
 
     internal const NodeType NTYPE  = NodeType.Ntype_R6;   // pshaffer


### PR DESCRIPTION
Please review. This fix allow connect to Erlang 20. Thank you!